### PR TITLE
Add simple asynchronous processing example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,5 @@ tokio-io = "0.1"
 
 [dev-dependencies]
 tokio-core = "0.1"
+tokio-codec = "0.1.0"
 tokio = "0.1"

--- a/examples/line-by-line.rs
+++ b/examples/line-by-line.rs
@@ -1,0 +1,35 @@
+extern crate tokio_stdin_stdout;
+extern crate tokio;
+extern crate tokio_io;
+extern crate tokio_codec;
+
+use tokio::prelude::future::ok;
+use tokio::prelude::{Future, Stream};
+use tokio_io::io::write_all as tokio_write_all;
+use tokio_codec::{FramedRead, LinesCodec};
+
+fn async_op(input: String) -> Box<Future<Item = String, Error = ()> + Send> {
+  Box::new(ok(input.to_ascii_uppercase()))
+}
+
+fn main() {
+  let stdin = tokio_stdin_stdout::stdin(0);
+  let stdout = tokio_stdin_stdout::stdout(0).make_sendable();
+
+  let framed_stdin = FramedRead::new(stdin, LinesCodec::new());
+  let future = framed_stdin.for_each(move |line| {
+    let stdout_ = stdout.clone();
+    let future_compute = async_op(line).and_then(|mut result| {
+      result.push_str("\n");
+      let future_write = tokio_write_all(stdout_, result).map(drop).map_err(drop);
+      return future_write;
+    });
+
+    tokio::run(future_compute);
+    Ok(())
+  }).map_err(|err| {
+    panic!("Error: {:?}", err);
+  });
+
+  tokio::run(future);
+}


### PR DESCRIPTION
This is a simple example which reads from stdin line by line, an asynchronous operation is applied to each line, and the output is written to stdout asynchronously.

I think this example could help people get started with the lib. From my point of view this is a common use case ‒ at least it is was a scenario that I needed the lib for and I had similar use cases in the past.                                                                                                             

If you decide against merging it, I would still be interested in feedback if this is the idiomatic way to use the lib.

This is how the example behaves:
```
$ yes foobar | head -n5 | cargo run --example line-by-line
    Finished dev [unoptimized + debuginfo] target(s) in 0.09s
     Running `target/debug/examples/line-by-line`                                                                                                                        
FOOBAR                                                                                                                                                                   
FOOBAR
FOOBAR
FOOBAR
FOOBAR
```